### PR TITLE
routeGuard.js linting

### DIFF
--- a/src/routeGuard.ts
+++ b/src/routeGuard.ts
@@ -49,7 +49,7 @@ export function createRouteGuard(
     // Then lets clear the candidates list
     sharedElementCandidates.clear()
 
-    subSharedElements.forEach((el) => (el.style.visibility = 'hidden'))
+    subSharedElements.forEach((el) => { el.style.visibility = 'hidden' })
 
     // Move on to the next middleware
     next()


### PR DESCRIPTION
the forEach loop should not use "return" style syntax, as the return value is not used